### PR TITLE
Fix MariaDB indexes renaming

### DIFF
--- a/updates/v2.0.1/rename_indexes.php
+++ b/updates/v2.0.1/rename_indexes.php
@@ -37,13 +37,27 @@ class RenameIndexes extends Migration
         $sm = Schema::getConnection()->getDoctrineSchemaManager();
 
         foreach ($sm->listTableIndexes($table) as $index) {
-            if ($index->isPrimary() === false) {
-                $old = $index->getName();
-                $new = str_replace($from, $to, $old);
-                Schema::table($table, function ($table) use ($old, $new) {
-                    $table->renameIndex($old, $new);
-                });
+            if ($index->isPrimary()) {
+                continue;
             }
+
+            $old = $index->getName();
+            $new = str_replace($from, $to, $old);
+
+            $columns = $index->getColumns();
+            if ($index->isUnique()) {
+                $indexType = 'Unique';
+            } else {
+                $indexType = 'Index';
+            }
+
+            Schema::table($table, function ($table) use ($indexType, $columns, $old, $new) {
+                $dropFunction = 'drop'.$indexType;
+                $createFunction = strtolower($indexType);
+
+                $table->$dropFunction($old);
+                $table->$createFunction($columns, $new);
+            });
         }
     }
 }

--- a/updates/v2.0.1/rename_indexes.php
+++ b/updates/v2.0.1/rename_indexes.php
@@ -36,7 +36,9 @@ class RenameIndexes extends Migration
     {
         $sm = Schema::getConnection()->getDoctrineSchemaManager();
 
-        foreach ($sm->listTableIndexes($table) as $index) {
+        $table = $sm->listTableDetails($table);
+
+        foreach ($table->getIndexes() as $index) {
             if ($index->isPrimary()) {
                 continue;
             }
@@ -44,20 +46,7 @@ class RenameIndexes extends Migration
             $old = $index->getName();
             $new = str_replace($from, $to, $old);
 
-            $columns = $index->getColumns();
-            if ($index->isUnique()) {
-                $indexType = 'Unique';
-            } else {
-                $indexType = 'Index';
-            }
-
-            Schema::table($table, function ($table) use ($indexType, $columns, $old, $new) {
-                $dropFunction = 'drop'.$indexType;
-                $createFunction = strtolower($indexType);
-
-                $table->$dropFunction($old);
-                $table->$createFunction($columns, $new);
-            });
+            $table->renameIndex($old, $new);
         }
     }
 }


### PR DESCRIPTION
MariaDB does not support renaming index on the latest LTS, we need to drop/recreate them.